### PR TITLE
Fix for the recent changes on rubocop

### DIFF
--- a/lib/rubocop/haml/ruby_extractor.rb
+++ b/lib/rubocop/haml/ruby_extractor.rb
@@ -26,13 +26,18 @@ module RuboCop
 
         ruby_ranges.map do |(begin_, end_)|
           clip = RubyClipper.new(template_source[begin_...end_]).call
+
+          processed_source = ::RuboCop::ProcessedSource.new(
+            clip[:code],
+            @processed_source.ruby_version,
+            file_path
+          )
+          processed_source.config = @processed_source.config
+          processed_source.registry = @processed_source.registry
+
           {
             offset: begin_ + clip[:offset],
-            processed_source: ::RuboCop::ProcessedSource.new(
-              clip[:code],
-              @processed_source.ruby_version,
-              file_path
-            )
+            processed_source: processed_source
           }
         end
       end


### PR DESCRIPTION
This PR fixes errors like

```
An error occurred while Lint/Syntax cop was inspecting /home/peter/devel/gitlab/gdk/gitlab/app/views/admin/users/projects.html.haml.
undefined method `disabled' for nil:NilClass
/home/peter/.dotfiles/asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rubocop-1.50.2/lib/rubocop/comment_config.rb:116:in `inject_disabled_cops_directives'
/home/peter/.dotfiles/asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rubocop-1.50.2/lib/rubocop/comment_config.rb:100:in `analyze'
/home/peter/.dotfiles/asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rubocop-1.50.2/lib/rubocop/comment_config.rb:52:in `cop_disabled_line_ranges'
/home/peter/.dotfiles/asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rubocop-1.50.2/lib/rubocop/comment_config.rb:41:in `cop_enabled_at_line?'
/home/peter/.dotfiles/asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rubocop-1.50.2/lib/rubocop/cop/base.rb:449:in `enabled_line?'
```

See also https://github.com/r7kamura/rubocop-erb/commit/6041db42955418b47ebd25b070dfd33ab67b560a