### PR TITLE
Fix syntax errors for do blocks with trailing code comments

### DIFF
--- a/lib/rubocop/haml/ruby_clipper.rb
+++ b/lib/rubocop/haml/ruby_clipper.rb
@@ -96,6 +96,7 @@ module RuboCop
           [ \t]*
           (\|[^|]*\|)?
           [ \t]*
+          (\#.*)?
           \Z
         /x.freeze
 

--- a/spec/fixtures/dummy.haml
+++ b/spec/fixtures/dummy.haml
@@ -1,2 +1,5 @@
 %div(a="b #{?c}")
 %div{ :a => "b" }
+
+- array.each do |element| # disable:rubocop <- this is ignored
+  = element

--- a/spec/rubocop/haml/ruby_extractor_spec.rb
+++ b/spec/rubocop/haml/ruby_extractor_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe RuboCop::Haml::RubyExtractor do
       'dummy.haml'
     end
 
-    let(:source) do
-      <<~HAML
-        a
-        = b
-        - array.each do |element|
-          = element
-      HAML
-    end
-
     context 'with valid condition' do
+      let(:source) do
+        <<~HAML
+          a
+          = b
+          - array.each do |element|
+            = element
+        HAML
+      end
+
       it 'returns Ruby codes with offset' do
         result = subject
         expect(result.length).to eq(3)
@@ -38,6 +38,24 @@ RSpec.describe RuboCop::Haml::RubyExtractor do
         expect(result[1][:offset]).to eq(8)
         expect(result[2][:processed_source].raw_source).to eq('element')
         expect(result[2][:offset]).to eq(36)
+      end
+    end
+
+    context 'with trailing code comments after do block' do
+      let(:source) do
+        <<~HAML
+          - array.each do |element| # code comment
+            = element
+        HAML
+      end
+
+      it 'returns Ruby codes with offset' do
+        result = subject
+        expect(result.length).to eq(2)
+        expect(result[0][:processed_source].raw_source).to eq('array.each')
+        expect(result[0][:offset]).to eq(2)
+        expect(result[1][:processed_source].raw_source).to eq('element')
+        expect(result[1][:offset]).to eq(45)
       end
     end
 


### PR DESCRIPTION
Previously, the following HAML code raised
`Lint/Syntax: unexpected token $end`:

```haml
- array.each do |element| # code comment
  = element
```

We now also drop the optional trailing code comment.

Only downside: RuboCop inline disables are ignored in those cases.

## Reproduction

1. Checkout this branch
2. Revert changes to `main` for `lib/` (via `git checkout main -- lib`)
3. Check `dummy.haml` via ` bundle exec rubocop -C false spec/fixtures/dummy.haml`
4. See `Lint/Syntax`:

```
spec/fixtures/dummy.haml:4:63: E: Lint/Syntax: unexpected token $end
(Using Ruby 2.6 parser; configure using TargetRubyVersion parameter, under AllCops)
- array.each do |element| # disable:rubocop <- this is ignored
```

5. Apply fix (`git reset --hard`)
6. Re-run RuboCop to see _that_ offense disappeared :tada: 