### PR TITLE
Fix bug that `Lint/Syntax` is not properly disabled

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -123,7 +123,7 @@ Lint/EmptyFile:
   Exclude:
     - '**/*.haml'
 
-Lint/SyntaxError:
+Lint/Syntax:
   Exclude:
     - '**/*.haml'
 


### PR DESCRIPTION
Same as:

- https://github.com/r7kamura/rubocop-slim/pull/27